### PR TITLE
Provisioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM clojure:openjdk-17-lein-alpine
+
+RUN mkdir -p /scramble-api
+
+RUN mkdir -p /scramble-frontend

--- a/README.org
+++ b/README.org
@@ -47,23 +47,22 @@
 
 *** How to run
 
-    Since there's no =HTTP Server= providing this frontend, please,
-    open the file located at
-    =scramble-frontend/resources/public/index.html= in your preferred
-    browser.
-
-    If you wish to rebuild the page, again, use =leiningen= to do so:
+    To build the page, again, use =leiningen=:
 
     #+BEGIN_SRC sh
     > cd scramble-frontend/
     > lein cljsbuild once dev
     #+END_SRC
 
-    You can also have it automatically rebuild the page, in case of
-    changes, by running:
+    If you wish to tweak the code, you can also have it automatically
+    rebuild the page, in case of changes, by running:
 
     #+BEGIN_SRC sh
     > cd scramble-frontend/
     > lein cljsbuild auto dev
     #+END_SRC
 
+    Since there's no =HTTP Server= providing this frontend, please,
+    open the file located at
+    =scramble-frontend/resources/public/index.html= in your preferred
+    browser.

--- a/README.org
+++ b/README.org
@@ -40,6 +40,26 @@
     > lein run
     #+END_SRC
 
+    You can also use =Docker/Docker Compose= in case you don't have or
+    wish to have all the dependecies in your local environment.
+
+    First, build, create and start the container with the virtual
+    environment by running:
+
+    #+BEGIN_SRC sh
+    > docker-compose up -d
+    #+END_SRC
+
+    This approach avoids having to reinstall the dependecies every time
+    the container is created, especially because there isn't an obvious
+    way of "pre-installing" the project dependencies using =leiningen=.
+
+    Now, run the server:
+
+    #+BEGIN_SRC sh
+    > docker-compose exec -w '/scramble-api' scramble-env sh -c "lein run"
+    #+END_SRC
+
 ** UI Application
 
    All source files are contained in the =scramble-frontend/=
@@ -60,6 +80,19 @@
     #+BEGIN_SRC sh
     > cd scramble-frontend/
     > lein cljsbuild auto dev
+    #+END_SRC
+
+    Or, using =Docker/Docker Compose= (remember to build/start the
+    container):
+
+    #+BEGIN_SRC sh
+    > docker-compose exec -w '/scramble-frontend' scramble-env sh -c "lein cljsbuild once dev"
+    #+END_SRC
+
+    Or, have it watch for changes with:
+
+    #+BEGIN_SRC sh
+    > docker-compose exec -w '/scramble-frontend' scramble-env sh -c "lein cljsbuild auto dev"
     #+END_SRC
 
     Since there's no =HTTP Server= providing this frontend, please,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.0'
+
+services:
+  scramble-env:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./scramble/:/scramble-api
+      - ./scramble-frontend/:/scramble-frontend
+    ports:
+      - "8080:8080"
+    restart: always
+    command: [ "tail", "-f", "/dev/null" ]

--- a/scramble-frontend/README.org
+++ b/scramble-frontend/README.org
@@ -36,8 +36,8 @@
 ** How to run
 
    Since there's no =HTTP Server= providing this frontend, please,
-   open the file located at =resources/public/index.html= in your
-   preferred browser.
+   open the file located at =resources/public/index.html=, after the
+   build process, in your preferred browser.
 
    In case the =API= is not running in =localhost:8080=, please edit
    the file =src/scramble_frontend/config.cljs= and add the correct

--- a/scramble-frontend/README.org
+++ b/scramble-frontend/README.org
@@ -20,7 +20,7 @@
 
 ** How to build
 
-   For building the web page, use leiningen:
+   For building the web page, use =leiningen=:
 
    #+BEGIN_SRC sh
    > lein cljsbuild once dev
@@ -31,6 +31,32 @@
 
    #+BEGIN_SRC sh
    > lein cljsbuild auto dev
+   #+END_SRC
+
+   You can also use =Docker/Docker Compose= in case you don't have or
+   wish to have all the dependecies in your local environment.
+
+   First, build, create and start the container with the virtual
+   environment by running:
+
+   #+BEGIN_SRC sh
+   > docker-compose up -d
+   #+END_SRC
+
+   This approach avoids having to reinstall the dependecies every time
+   the container is created, especially because there isn't an obvious
+   way of "pre-installing" the project dependencies using =leiningen=.
+
+   Now build the page with:
+
+   #+BEGIN_SRC sh
+   > docker-compose exec -w '/scramble-frontend' scramble-env sh -c "lein cljsbuild once dev"
+   #+END_SRC
+
+   Or, have it watch for changes with:
+
+   #+BEGIN_SRC sh
+   > docker-compose exec -w '/scramble-frontend' scramble-env sh -c "lein cljsbuild auto dev"
    #+END_SRC
 
 ** How to run
@@ -50,6 +76,8 @@
    ;; Defines the api host for sending the requests.
    (def api-host "API_LOCATION")
    #+END_SRC
+
+   Then, rebuild the page.
 
 * References
 

--- a/scramble/README.org
+++ b/scramble/README.org
@@ -53,6 +53,16 @@
    Nope, sorry.
    #+END_SRC
 
+   You can change the default value for the api and port in the file
+   =src/scramble_frontend/config.cljs=, i.e.:
+
+   #+BEGIN_SRC clojure
+   ;; Defines the api port for sending the requests.
+   (def api-port "DESIRED_PORT")
+   #+END_SRC
+
+   Or you can set the environment varialbe =SCRAMBLE_PORT=.
+
 * References
 
   - [[https://leiningen.org][https://leiningen.org]]

--- a/scramble/README.org
+++ b/scramble/README.org
@@ -23,7 +23,27 @@
    Use leiningen:
 
    #+BEGIN_SRC sh
-   lein run
+   > lein run
+   #+END_SRC
+
+   You can also use =Docker/Docker Compose= in case you don't have or
+   wish to have all the dependecies in your local environment.
+
+   First, build, create and start the container with the virtual
+   environment by running:
+
+   #+BEGIN_SRC sh
+   > docker-compose up -d
+   #+END_SRC
+
+   This approach avoids having to reinstall the dependecies every time
+   the container is created, especially because there isn't an obvious
+   way of "pre-installing" the project dependencies using =leiningen=.
+
+   Now, run the server:
+
+   #+BEGIN_SRC sh
+   > docker-compose exec -w '/scramble-api' scramble-env sh -c "lein run"
    #+END_SRC
 
 ** How to test
@@ -31,7 +51,14 @@
    Again, use leiningen:
 
    #+BEGIN_SRC sh
-   lein test
+   > lein test
+   #+END_SRC
+
+   And, with =Docker=, remember to build the environment as stated
+   above, then run:
+
+   #+BEGIN_SRC sh
+   > docker-compose exec -w '/scramble-api' scramble-env sh -c "lein test"
    #+END_SRC
 
 ** API Routes


### PR DESCRIPTION
# Description

Add a simple provisioning structure to the project

# How to use

For both the `api` and the `frontend`, from the project's root, build the virtual environment with:

```
> docker-compose up -d
```

Now run the `api` with:

```
> docker-compose exec -w '/scramble-api' scramble-env sh -c "lein run"
```

And build the web page with:

```
> docker-compose exec -w '/scramble-frontend' scramble-env sh -c "lein cljsbuild once dev"
```